### PR TITLE
Extern ui to prevent multiple definitions

### DIFF
--- a/include/switchui/ui.h
+++ b/include/switchui/ui.h
@@ -36,7 +36,7 @@ typedef struct {
   int buttonBWidth, buttonBHeight;
 } SUI;
 
-SUI ui;
+extern SUI ui;
 
 enum SUIToolbarAction {
   SUIToolbarActionA, SUIToolbarActionB

--- a/source/ui.c
+++ b/source/ui.c
@@ -9,6 +9,8 @@
 #include "button_a_png.h"
 #include "button_b_png.h"
 
+SUI ui;
+
 static int shared_fonts_init() {
   plInitialize();
 


### PR DESCRIPTION
Leaving the definition of ui in the header file makes it impossible to include switchui in multiple files. I've moved the definition to the c file instead!